### PR TITLE
Scanner Никитин А.О. ПИ20-3

### DIFF
--- a/scanner.py
+++ b/scanner.py
@@ -1,15 +1,24 @@
 import socket
-from threading import Thread
+import threading
+import pyprind
 
-N = 2**16 - 1
+N = 65536
 
-for port in range(1,100):
-    sock = socket.socket()
+Progress = pyprind.ProgBar(N)
+
+ip = '192.168.0.1'
+
+def scan_port(ip,port):
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    sock.settimeout(0.5)
     try:
-        print(port)
-        sock.connect(('127.0.0.1', port))
-        print("Порт", i, "открыт")
-    except:
-        continue
-    finally:
+        connect = sock.connect((ip,port))
+        print(f'\nport {port} is open')
         sock.close()
+    except:
+        pass
+    finally:
+        Progress.update()
+
+if __name__ == '__main__':
+    [threading.Thread(target=scan_port, args=(ip, i)).start() for i in range(N)]


### PR DESCRIPTION
Ошибка "to many open files" возникает из-за ограничения на максимально возможное количество открытых файлов со стороны ОС.
По умолчанию, если вы работаете с Linux, у вас стоит ограничение на максимально возможное количество открытых файлов. Узнать свое ограничение можно прописав в консоли команду "ulimit -n". Для того чтобы моя программа спокойно работала, нужно увеличить ограничение максимально возможного количества открытых файлов командой. Это можно сделать по быстрому, для этого нужно стать суперпользователем (sudo bash), и прописать команду "ulimit -n 100000", в дальнейшем можно выйти из рута, и запускать мою программу через sudo "sudo python3 scanner.py".
В macos это сделать невозможно, из за аппаратных ограничений от apple. В windows это значение по умолчанию большое. Поэтому проблем не должно возникнуть.